### PR TITLE
[Chore] README.md: Adjusted the 'Phong Reflection Model'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It loosely follows the steps described in [The Ray Tracer Challenge](http://rayt
 
 ### Phong Reflection Model
 
-| Ambient Reflection| Diffuse Reflection | Specular Reflection | Result |
-| :----------------:| :----------------: | :-----------------: | :----: |
-| ![Ambient Reflection of a sphere](../assets/readme/phong-shading-01-ambient-reflection.png?raw=true) | ![Diffuse Reflection of a sphere](../assets/readme/phong-shading-02-diffuse-reflection.png?raw=true)| ![Specular Reflection of a sphere](../assets/readme/phong-shading-03-specular-reflection.png?raw=true) | ![Phong Reflection Render Result of a sphere](../assets/readme/phong-shading-04-result.png?raw=true) |
+| Ambient Reflection  | Diffuse Reflection  | Specular Reflection |       Result        |
+| :-----------------: | :-----------------: | :-----------------: | :-----------------: |
+| <img src="../assets/readme/phong-shading-01-ambient-reflection.png?raw=true" alt="Ambient Reflection of a sphere" width="220" /> | <img src="../assets/readme/phong-shading-02-diffuse-reflection.png?raw=true" alt="Diffuse Reflection of a sphere" width="220" /> | <img src="../assets/readme/phong-shading-03-specular-reflection.png?raw=true" alt="Specular Reflection of a sphere" width="220" /> | <img src="../assets/readme/phong-shading-04-result.png?raw=true" alt="Phong Reflection Render Result of a sphere" width="220" /> |
 
 ## Usage
 


### PR DESCRIPTION
Previously, the markdown table wasn't using equal sizing of the
cells on smaller screens. This change unifies the usage of the
hyphen cell delimiter and switches to `<img>` tags to control
the width of each image in the rendered cell.